### PR TITLE
add google analytics to main document, 

### DIFF
--- a/lib/gtag.js
+++ b/lib/gtag.js
@@ -1,0 +1,17 @@
+export const GA_TRACKING_ID = 'UA-165985850-1'
+
+// https://developers.google.com/analytics/devguides/collection/gtagjs/pages
+export const pageview = url => {
+  window.gtag('config', GA_TRACKING_ID, {
+    page_path: url,
+  })
+}
+
+// https://developers.google.com/analytics/devguides/collection/gtagjs/events
+export const event = ({ action, category, label, value }) => {
+  window.gtag('event', action, {
+    event_category: category,
+    event_label: label,
+    value: value,
+  })
+}

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,12 +1,31 @@
 import React from 'react'
 import Document, { Html, Head, Main, NextScript } from 'next/document'
 import { InitializeColorMode } from 'theme-ui'
+import { GA_TRACKING_ID } from '../lib/gtag'
 
 class MyDocument extends Document {
   render() {
     return (
       <Html className='no-focus-outline'>
-        <Head />
+        <Head>
+          {/* Global Site Tag (gtag.js) - Google Analytics */}
+          <script
+            async
+            src={`https://www.googletagmanager.com/gtag/js?id=${GA_TRACKING_ID}`}
+          />
+          <script
+            dangerouslySetInnerHTML={{
+              __html: `
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+            gtag('config', '${GA_TRACKING_ID}', {
+              page_path: window.location.pathname,
+            });
+          `,
+            }}
+          />
+        </Head>
         <body>
           <InitializeColorMode />
           <Main />


### PR DESCRIPTION
follows https://github.com/zeit/next.js/tree/canary/examples/with-google-analytics

see also https://github.com/carbonplan/carbonplan.org/pull/2