### PR TITLE
Upgrade pre-commit hooks to fix bug in old `black` version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ ci:
 exclude: ^(secrets/|data/)
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.3.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -16,13 +16,13 @@ repos:
         args: ['--autofix', '--indent=2', '--no-sort-keys']
 
   - repo: https://github.com/psf/black
-    rev: 21.12b0
+    rev: 22.6.0
     hooks:
       - id: black
         args: ['--line-length', '100', '--skip-string-normalization']
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
+    rev: 5.0.4
     hooks:
       - id: flake8
 
@@ -35,7 +35,7 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: 'v2.5.1'
+    rev: 'v2.7.1'
     hooks:
       - id: prettier
         language_version: system
@@ -50,7 +50,7 @@ repos:
           |yaml|yml\
           )$"
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: 'v2.5.1'
+    rev: 'v2.7.1'
     hooks:
       - id: prettier
         name: prettier-markdown


### PR DESCRIPTION
This is an attempt at fixing pre-commit runs. The failures are caused by a bug/version incompatibitility in a previous release of `black`

```python
- hook id: black
- exit code: 1

Traceback (most recent call last):
  File "/pc/clone/90epvBe_TZSpikLrtoJGyg/py_env-python3/bin/black", line 8, in <module>
    sys.exit(patched_main())
  File "/pc/clone/90epvBe_TZSpikLrtoJGyg/py_env-python3/lib/python3.10/site-packages/black/__init__.py", line 1372, in patched_main
    patch_click()
  File "/pc/clone/90epvBe_TZSpikLrtoJGyg/py_env-python3/lib/python3.10/site-packages/black/__init__.py", line 1358, in patch_click
    from click import _unicodefun
ImportError: cannot import name '_unicodefun' from 'click' (/pc/clone/90epvBe_TZSpikLrtoJGyg/py_env-python3/lib/python3.10/site-packages/click/__init__.py)

```